### PR TITLE
TASK: Adds filter to trigger circle ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,14 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - checkout
+      - checkout:
+          filters:
+            tags:
+              only:
+                - /^\d\.\d\.\d/
+            branches:
+              only:
+                - /.*/
       - build_flow_app:
           requires:
             - checkout


### PR DESCRIPTION
The circle ci tests are running only on branch changes by default.
So when a new tag has been pushed the build chain will not run.
This is now enabled for tags that follow the scheme x.x.x
